### PR TITLE
Fix KeyError: 'duration'

### DIFF
--- a/ffmpeg_progress.py
+++ b/ffmpeg_progress.py
@@ -117,7 +117,7 @@ def start(infile: str,
         raise ValueError('Cannot use input FPS')
     if fps == 0:
         raise ValueError('Unexpected zero FPS')
-    dur = float(probe['streams'][index]['duration'])
+    dur = float(probe['format']['duration'])
     total_frames = int(dur * fps)
 
     if total_frames <= 0:


### PR DESCRIPTION
Videos don't always have the duration listed under streams from ffprobe.
But on the other hand, duration is always present under the format section, so using that instead.

Fixes issue #1 